### PR TITLE
Incorporate Christian revisions & fix a bug with creating events from annotations

### DIFF
--- a/eoglearn/datasets/mne.py
+++ b/eoglearn/datasets/mne.py
@@ -68,9 +68,12 @@ def read_mne_eyetracking_raw(return_events=False, bandpass=True):
     # Add EEG channels to the eye-tracking raw object
     raw_et.add_channels([raw_eeg], force_update_info=True)
 
-    annots = mne.annotations_from_events(eeg_events, raw_et.info["sfreq"],
-                                         event_desc={2: "Flash"},
-                                         orig_time=raw_et.info["meas_date"])
+    annots = mne.annotations_from_events(
+        et_events,
+        raw_et.info["sfreq"],
+        event_desc={2: "Flash"},
+        orig_time=raw_et.info["meas_date"],
+    )
     raw_et.set_annotations(raw_et.annotations + annots)
 
     if return_events:

--- a/eoglearn/models/model.py
+++ b/eoglearn/models/model.py
@@ -4,8 +4,8 @@
 # License: BSD-3-Clause
 
 import matplotlib.pyplot as plt
-import numpy as np
 import mne
+import numpy as np
 from mne.utils import logger
 from sklearn.preprocessing import StandardScaler
 from tensorflow.keras.layers import LSTM
@@ -34,6 +34,7 @@ class EOGDenoiser:
         The number of timepoints to pass into the LSTM model at once. Defaults to 100.
     noise_picks: list | None
         Channels that contain the noise channels.
+
     Attributes
     ----------
     raw : mne.io.Raw
@@ -73,14 +74,7 @@ class EOGDenoiser:
     on how to create a raw object with both EEG and eyetracking channels.
     """
 
-    def __init__(
-        self,
-        raw,
-        downsample=10,
-        n_units=50,
-        n_times=100,
-        noise_picks=None
-    ):
+    def __init__(self, raw, downsample=10, n_units=50, n_times=100, noise_picks=None):
         self.__x = None
         self.__y = None
         #############################################
@@ -106,6 +100,7 @@ class EOGDenoiser:
 
     @property
     def denoised_neural(self):
+        """Return the MEEG signal without EOG artifact."""
         if self.__denoised_neural is None:
             logger.info(
                 "Denoising neural data, saving to ``denoised_neural_`` attribute."
@@ -292,6 +287,7 @@ class EOGDenoiser:
         self.__denoised_neural = Y_train - predicted_eog
 
     def get_denoised_neural_raw(self):
+        """Return an mne.io.Raw object of the MEEG signal without EOG artifact."""
         raw_y = self._get_y_raw()
         raw_denoised = mne.io.RawArray(self.denoised_neural.T, raw_y.info)
         raw_denoised.set_annotations(raw_y.annotations)

--- a/eoglearn/viz/topo.py
+++ b/eoglearn/viz/topo.py
@@ -93,5 +93,5 @@ def plot_values_topomap(
 
     if colorbar:
         fig.colorbar(im[0], ax=axes, shrink=0.6, label="Percentage of EOG in signal")
-    plt_show(show)
+    plt_show(show, fig)
     return fig

--- a/examples/plot_model.py
+++ b/examples/plot_model.py
@@ -11,6 +11,7 @@ channels..
 # %%
 # Import the necessary packages
 import mne
+import matplotlib.pyplot as plt
 from eoglearn.datasets import read_mne_eyetracking_raw
 from eoglearn.models import EOGDenoiser
 
@@ -38,6 +39,8 @@ eog_denoiser
 # %%
 # Fit the model
 # We will only use 10 epochs to speed up the example
+
+# %%
 eog_denoiser.fit_model(epochs=10)
 history = eog_denoiser.model.history
 
@@ -45,6 +48,7 @@ history = eog_denoiser.model.history
 # display the training history
 print(history.history["loss"])
 print(history.history["val_loss"])
+eog_denoiser.plot_loss()
 
 # %%
 # Plot a topomap of the predicted EOG artifact.
@@ -52,6 +56,8 @@ print(history.history["val_loss"])
 # The plot below displays the predicted amount of EOG artifact for each EEG sensor.
 # The output is as we would expect, with frontal sensors containing the most EOG
 # artifact.
+
+# %%
 montage = mne.channels.make_standard_montage("GSN-HydroCel-129")
 eog_denoiser.plot_eog_topo(montage=montage)
 
@@ -59,3 +65,33 @@ eog_denoiser.plot_eog_topo(montage=montage)
 # .. todo::
 #    Add a plot of the predicted EOG artifact for each EEG sensor over time.
 #    Add plots of the denoised EEG data.
+
+# %%
+# Compare ERP between the original and "EOG-denoised" signals
+# -----------------------------------------------------------
+#
+# Let's create an averaged evoked response to the flash stimuli for both the original
+# data and the "EOG-denoised" data. We'll focus on the frontal EEG channels, since it is
+# these will contain the most EOG in the original signal.
+
+# %%
+pred_raw = eog_denoiser.get_denoised_neural_raw()
+events, event_id = mne.events_from_annotations(pred_raw, regexp="Flash")
+pred_epochs = mne.Epochs(
+    pred_raw, events=events, event_id=event_id, tmin=-0.3, tmax=3, preload=True
+)
+
+events, event_id = mne.events_from_annotations(eog_denoiser.raw, regexp="Flash")
+original_epochs = mne.Epochs(
+    eog_denoiser.raw, events=events, event_id=event_id, tmin=-0.3, tmax=3, preload=True
+)
+
+frontal = ["E19", "E11", "E4", "E12", "E5"]
+pred_avg_frontal = pred_epochs.average().get_data(picks=frontal).mean(0)
+original_avg_frontal = original_epochs.average().get_data(picks=frontal).mean(0)
+
+ax = plt.subplot()
+ax.plot(pred_epochs.times, pred_avg_frontal, label="predicted")
+ax.plot(original_epochs.times, original_avg_frontal, label="original")
+ax.set_xlim(-0.3, 1)
+ax.legend()


### PR DESCRIPTION
This branch was pulled from Christian's forks, and added a couple fixes on top.


Regarding the issue where the Evoked responses appeared to not be time-locked to the flash stimulus, Our initial suspect of annotations was true. In the initial commit of this PR, in `eoglearn/datasets/mne.py`, we set the EEG annotations to the ET raw object. The fix is to set the ET annotations to the ET object (which also contains EEG channels, bc we did `raw_et.add_channels([raw_eeg])`.
