### PR TITLE
FIX: Make sure eegeyenet_urls.csv gets included in package data durin…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ source = 'https://github.com/scott-huberty/EOGLearn'
 tracker = 'https://github.com/scott-huberty/EOGLearn/issues'
 # documentation = 'https://github.com/scott-huberty/EOGLearn/'
 
-[tool.setuptools]
-include-package-data = false
-
 [tool.setuptools.packages.find]
 include = ['eoglearn*']
 exclude = ['eoglearn*tests']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ source = 'https://github.com/scott-huberty/EOGLearn'
 tracker = 'https://github.com/scott-huberty/EOGLearn/issues'
 # documentation = 'https://github.com/scott-huberty/EOGLearn/'
 
+[tool.setuptools]
+include-package-data = false
+
 [tool.setuptools.packages.find]
 include = ['eoglearn*']
 exclude = ['eoglearn*tests']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ tracker = 'https://github.com/scott-huberty/EOGLearn/issues'
 # documentation = 'https://github.com/scott-huberty/EOGLearn/'
 
 [tool.setuptools]
-include-package-data = True
+include-package-data = true
 
 [tool.setuptools.packages.find]
 include = ['eoglearn*']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools >= 61.0.0']
+requires = ['setuptools >= 61.0.0', "setuptools-scm>=8.0"]
 build-backend = 'setuptools.build_meta'
 
 [project]
@@ -91,7 +91,7 @@ include = ['eoglearn*']
 exclude = ['eoglearn*tests']
 
 # [tool.setuptools.package-data]
-# "eoglearn" = ["assets/*"]
+# "eoglearn" = ["assets/*", "datasets/eegeyenet_urls.csv"]
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ tracker = 'https://github.com/scott-huberty/EOGLearn/issues'
 # documentation = 'https://github.com/scott-huberty/EOGLearn/'
 
 [tool.setuptools]
-include-package-data = false
+include-package-data = True
 
 [tool.setuptools.packages.find]
 include = ['eoglearn*']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,9 +90,6 @@ include-package-data = true
 include = ['eoglearn*']
 exclude = ['eoglearn*tests']
 
-# [tool.setuptools.package-data]
-# "eoglearn" = ["assets/*", "datasets/eegeyenet_urls.csv"]
-
 [tool.black]
 line-length = 88
 target-version = ['py39']


### PR DESCRIPTION
The CSV file added in 957f98d isn't getting downloaded during static install.

Might be because of the include_package_data flag, 

see: 

https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distutils


Keeping as draft until I can test this out.